### PR TITLE
Add AdminLTE test view and locale settings

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -108,9 +108,9 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/5.2/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = 'ja'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'Asia/Tokyo'
 
 USE_I18N = True
 

--- a/app/urls.py
+++ b/app/urls.py
@@ -16,7 +16,9 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
+from django.views.generic import TemplateView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('test/', TemplateView.as_view(template_name='test.html'), name='test'),
 ]

--- a/sns_core/templates/adminlte/lib/_main_sidebar.html
+++ b/sns_core/templates/adminlte/lib/_main_sidebar.html
@@ -1,0 +1,40 @@
+{% load adminlte_helpers %}
+{% load static %}
+<aside class="main-sidebar sidebar-dark-primary elevation-4">
+    {% block logo %}
+        <a href="/" class="brand-link">
+            <img src="{% static 'admin-lte/dist/img/AdminLTELogo.png' %}" alt="AdminLTE Logo" class="brand-image img-circle elevation-3" style="opacity: .8">
+            {% block logo_text %}<span class="brand-text font-weight-light">AdminLTE 3 </span>{% endblock %}
+        </a>
+    {% endblock %}
+    <div class="sidebar">
+        {% block user_panel %}
+        <div class="user-panel mt-3 pb-3 mb-3 d-flex">
+            <div class="image">
+                <img src="{% avatar_url size=90 %}" class="img-circle elevation-2" alt="User Image">
+            </div>
+            <div class="info">
+                <a href="#" class="d-block">{% firstof request.user.get_full_name request.user.username %}</a>
+            </div>
+        </div>
+        {% endblock %}
+        {% block form %}{% endblock %}
+        {% block nav_links_ul %}
+        <nav class="mt-2">
+            <ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
+                {% block nav_links_outer %}
+                <li class="nav-header">{% block nav_heading %}MAIN NAVIGATION{% endblock %}</li>
+                {% block nav_links %}
+                <li class="nav-item">
+                    <a href="{% url 'test' %}" class="nav-link">
+                        <i class="nav-icon fas fa-eye"></i>
+                        <p>表示テスト</p>
+                    </a>
+                </li>
+                {% endblock nav_links %}
+                {% endblock nav_links_outer %}
+            </ul>
+        </nav>
+        {% endblock nav_links_ul %}
+    </div>
+</aside>

--- a/sns_core/templates/test.html
+++ b/sns_core/templates/test.html
@@ -1,0 +1,7 @@
+{% extends 'adminlte/base.html' %}
+
+{% block content %}
+<div class="container">
+    <h1 class="display-1 text-center">テスト</h1>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Set Django locale to Japanese and Asia/Tokyo timezone
- Add TemplateView and AdminLTE sidebar link for `/test/`

## Testing
- `python manage.py check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6896a56f72148331a31db8596e3d5b10