### PR TITLE
Unify webhook endpoints and Docker startup

### DIFF
--- a/README_social.md
+++ b/README_social.md
@@ -2,13 +2,14 @@
 
 ## 予約投稿
 - 管理画面から作成し、「承認」するとスケジューラ対象になります。
-- スケジューラ実行(スタブ): `python manage.py shell -c "from social_core.services.scheduler import dispatch_scheduled_posts; dispatch_scheduled_posts()"`
+- Worker 実行: `python manage.py social_worker --loop`
 
 ## 投稿データ取り込み
 - 投稿一覧画面上部の「取り込む」「最新化する」ボタンから実行します。
 
 ## Webhook テスト
 - `/webhook/threads/` や `/webhook/instagram/` に POST すると `WebhookEvent` が作成されます。
+- Threads の DM API は未提供で、リプライ/メンションを DM 相当として扱います。
 
 ## .env サンプル
 
@@ -23,6 +24,7 @@ VERIFY_TOKEN_TH=test_token_th
 TH_APP_ID=123
 TH_APP_SECRET=xxx
 DEFAULT_API_VERSION=v23.0
+WORKER_INTERVAL_SEC=5
 ```
 
 ## Webhook 登録と検証
@@ -42,8 +44,5 @@ python manage.py social_worker --loop
 ```
 curl -X POST http://localhost:8000/webhook/instagram/ \
   -H 'Content-Type: application/json' \
-  -d '{"entry":[{"messaging":[{"sender":{"id":"u1"},"message":{"text":"hello"}}]}]}'
+  -d '{"entry":[{"changes":[{"field":"messages","value":{"messages":[{"from":{"id":"u1"},"text":"hello"}]}}]}]}'
 ```
-
-## スケジューラ
-- 予約投稿や配信のディスパッチはスタブです: `python manage.py shell -c "from social_core.services.scheduler import dispatch_scheduled_posts, dispatch_broadcasts; dispatch_scheduled_posts(); dispatch_broadcasts()"`

--- a/app/settings.py
+++ b/app/settings.py
@@ -40,11 +40,9 @@ INSTALLED_APPS = [
     'django_adminlte3',
     'sns_core',
     'social',
-    'webhooks',
     'social_core',
     'ig',
     'th',
-    'social_webhooks',
     'social_scheduler',
 ]
 

--- a/app/urls.py
+++ b/app/urls.py
@@ -15,18 +15,18 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import include, path
 from django.views.generic import TemplateView
 
 from social import views as social_views
+
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('social/', include('social.urls')),
     path('sns/ig/', include(('ig.urls', 'ig'), namespace='ig')),
     path('sns/th/', include(('th.urls', 'th'), namespace='th')),
-    # Legacy app handles some webhooks but new endpoints are provided below
-    path('webhooks/', include('social_webhooks.urls')),
+    # Webhooks are now consolidated under /webhook/* endpoints
     path('webhook/instagram/', social_views.webhook_instagram),
     path('webhook/threads/', social_views.webhook_threads),
     path('test/', TemplateView.as_view(template_name='test.html'), name='test'),

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,16 @@
-# backend/Dockerfile
 FROM python:3.12
 WORKDIR /app
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends netcat-openbsd \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --upgrade pip \
+ && pip install --no-cache-dir -r requirements.txt
+
 COPY . .
-RUN pip install --upgrade pip
-RUN pip install -r requirements.txt
-CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+echo "Waiting for DB ${MYSQL_HOST:-db}:${MYSQL_PORT:-3306} ..."
+until nc -z "${MYSQL_HOST:-db}" "${MYSQL_PORT:-3306}"; do
+  sleep 1
+done
+python manage.py migrate --noinput
+exec python manage.py runserver 0.0.0.0:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,12 +11,16 @@ services:
       - "3306:3306"
     volumes:
       - ./mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-u", "appuser", "--password=apppass"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 20s
 
   django:
     build: ./backend
-    command: python manage.py runserver 0.0.0.0:8000
     volumes:
-      - ./backend:/app
       - .:/app
     ports:
       - "8000:8000"
@@ -26,8 +30,11 @@ services:
       - MYSQL_DB=appdb
       - MYSQL_USER=appuser
       - MYSQL_PASSWORD=apppass
+    env_file:
+      - .env
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
   nginx:
     image: nginx:latest


### PR DESCRIPTION
## Summary
- consolidate webhooks under `/webhook/*` and update Instagram handler for `changes` payload
- document Threads DM limitation and environment variables
- add Docker entrypoint with DB wait and migration

## Testing
- `USE_SQLITE=1 python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a1d32327b48331b61bd10ea33c3acf